### PR TITLE
minify docker image (~10MB)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,4 @@
-FROM golang:1.7
-MAINTAINER Máximo Cuadros <mcuadros@gmail.com>
-
-ADD . ${GOPATH}/src/github.com/mcuadros/ofelia
-WORKDIR ${GOPATH}/src/github.com/mcuadros/ofelia
-
-RUN go get -v ./... \
- && go install -v ./... \
- && rm -rf $GOPATH/src/
-
-VOLUME /etc/ofelia/
-CMD ["ofelia", "daemon", "--config", "/etc/ofelia/config.ini"]
+FROM scratch
+#MAINTAINER Máximo Cuadros <mcuadros@gmail.com>
+ADD main /
+CMD ["/main", "daemon", "--config", "/etc/ofelia/config.ini"]

--- a/build
+++ b/build
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# brew install golang
+
+go get -d ./...
+
+CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
+


### PR DESCRIPTION
By pre-compiling the go we can minify the images size from 280MB to ~10MB.

You may want to tweak it a bit and update the docs accordingly.