### PR TITLE
Add container to a network on run

### DIFF
--- a/core/runjob_test.go
+++ b/core/runjob_test.go
@@ -29,6 +29,7 @@ func (s *SuiteRunJob) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	s.buildImage(c)
+	s.createNetwork(c)
 }
 
 func (s *SuiteRunJob) TestRun(c *C) {
@@ -38,6 +39,7 @@ func (s *SuiteRunJob) TestRun(c *C) {
 	job.User = "foo"
 	job.TTY = true
 	job.Delete = true
+	job.Network = "foo"
 
 	e := NewExecution()
 
@@ -100,6 +102,14 @@ func (s *SuiteRunJob) buildImage(c *C) {
 		Name:         ImageFixture,
 		InputStream:  inputbuf,
 		OutputStream: bytes.NewBuffer(nil),
+	})
+	c.Assert(err, IsNil)
+}
+
+func (s *SuiteRunJob) createNetwork(c *C) {
+	_, err := s.client.CreateNetwork(docker.CreateNetworkOptions{
+		Name: "foo",
+		Driver: "bridge",
 	})
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
This PR adds the ability to add a container to a network as suggested in #29.

I've created a test case too, but this only works after my PR to go-dockerclient is merged because the needed endpoint for NetworkConnect is not implemented right now.
(see https://github.com/fsouza/go-dockerclient/pull/675)
So I didn't included the test file yet.

Update: My PR has been merged, I added test files for my change. (Works with latest Go Dockerclient).