### PR TITLE
Features/docker service support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+ofelia
+debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 sudo: false
 
 go:
-  - 1.7.x
+  - 1.9.x
 
 script:
   - make test-coverage

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It uses a INI-style config file and the [scheduling format](https://godoc.org/gi
 - `job-exec`: this job is executed inside of a running container.
 - `job-run`: runs a command inside of a new container, using a specific image.
 - `job-local`: runs the command inside of the host running ofelia.
+- `job-service-run`: runs the command inside a new "run-once" service, for running inside a swarm
 
 
 ```ini
@@ -39,6 +40,13 @@ command = touch /tmp/example
 [job-local "job-executed-on-current-host"]
 schedule = @hourly
 command = touch /tmp/example
+
+
+[job-service-run "servie-executed-on-new-container"]
+schedule = 0,20,40 * * * *
+image = ubuntu
+network = swarm_network
+command =  touch /tmp/example
 ```
 
 ### Logging

--- a/cli/config.go
+++ b/cli/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	}
 	ExecJobs    map[string]*ExecJobConfig    `gcfg:"job-exec"`
 	RunJobs     map[string]*RunJobConfig     `gcfg:"job-run"`
-	ServiceJobs map[string]*RunServiceConfig `gcfg:"service-run"`
+	ServiceJobs map[string]*RunServiceConfig `gcfg:"job-service-run"`
 	LocalJobs   map[string]*LocalJobConfig   `gcfg:"job-local"`
 }
 

--- a/cli/config.go
+++ b/cli/config.go
@@ -19,9 +19,10 @@ type Config struct {
 		middlewares.SaveConfig
 		middlewares.MailConfig
 	}
-	ExecJobs  map[string]*ExecJobConfig  `gcfg:"job-exec"`
-	RunJobs   map[string]*RunJobConfig   `gcfg:"job-run"`
-	LocalJobs map[string]*LocalJobConfig `gcfg:"job-local"`
+	ExecJobs    map[string]*ExecJobConfig    `gcfg:"job-exec"`
+	RunJobs     map[string]*RunJobConfig     `gcfg:"job-run"`
+	ServiceJobs map[string]*RunServiceConfig `gcfg:"service-run"`
+	LocalJobs   map[string]*LocalJobConfig   `gcfg:"job-local"`
 }
 
 // BuildFromFile buils a scheduler using the config from a file
@@ -81,6 +82,14 @@ func (c *Config) build() (*core.Scheduler, error) {
 		sh.AddJob(j)
 	}
 
+	for name, j := range c.ServiceJobs {
+		defaults.SetDefaults(j)
+		j.Name = name
+		j.Client = d
+		j.buildMiddlewares()
+		sh.AddJob(j)
+	}
+
 	return sh, nil
 }
 
@@ -122,6 +131,14 @@ func (c *ExecJobConfig) buildMiddlewares() {
 }
 
 // RunJobConfig contains all configuration params needed to build a RunJob
+type RunServiceConfig struct {
+	core.RunServiceJob
+	middlewares.OverlapConfig
+	middlewares.SlackConfig
+	middlewares.SaveConfig
+	middlewares.MailConfig
+}
+
 type RunJobConfig struct {
 	core.RunJob
 	middlewares.OverlapConfig
@@ -151,4 +168,11 @@ func (c *LocalJobConfig) buildMiddlewares() {
 	c.LocalJob.Use(middlewares.NewSlack(&c.SlackConfig))
 	c.LocalJob.Use(middlewares.NewSave(&c.SaveConfig))
 	c.LocalJob.Use(middlewares.NewMail(&c.MailConfig))
+}
+
+func (c *RunServiceConfig) buildMiddlewares() {
+	c.RunServiceJob.Use(middlewares.NewOverlap(&c.OverlapConfig))
+	c.RunServiceJob.Use(middlewares.NewSlack(&c.SlackConfig))
+	c.RunServiceJob.Use(middlewares.NewSave(&c.SaveConfig))
+	c.RunServiceJob.Use(middlewares.NewMail(&c.MailConfig))
 }

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -25,10 +25,13 @@ func (s *SuiteConfig) TestBuildFromString(c *C) {
 
 		[job-local "baz"]
 		schedule = @every 10s
+
+		[job-service-run "bob"]
+		schedule = @every 10s
   `)
 
 	c.Assert(err, IsNil)
-	c.Assert(sh.Jobs, HasLen, 4)
+	c.Assert(sh.Jobs, HasLen, 5)
 }
 
 func (s *SuiteConfig) TestExecJobBuildEmpty(c *C) {

--- a/core/common.go
+++ b/core/common.go
@@ -7,7 +7,10 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 	"time"
+
+	docker "github.com/fsouza/go-dockerclient"
 )
 
 var (
@@ -211,4 +214,36 @@ func randomID() string {
 	}
 
 	return fmt.Sprintf("%x", b)
+}
+
+func buildPullOptions(image string) (docker.PullImageOptions, docker.AuthConfiguration) {
+	tag := "latest"
+	registry := ""
+
+	parts := strings.Split(image, ":")
+	if len(parts) == 2 {
+		tag = parts[1]
+	}
+
+	name := parts[0]
+	parts = strings.Split(name, "/")
+	if len(parts) > 2 {
+		registry = parts[0]
+	}
+
+	return docker.PullImageOptions{
+		Repository: name,
+		Registry:   registry,
+		Tag:        tag,
+	}, buildAuthConfiguration(registry)
+}
+
+func buildAuthConfiguration(registry string) docker.AuthConfiguration {
+	var auth docker.AuthConfiguration
+	if dockercfg == nil {
+		return auth
+	}
+
+	auth, _ = dockercfg.Configs[registry]
+	return auth
 }

--- a/core/runjob.go
+++ b/core/runjob.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/fsouza/go-dockerclient"
@@ -144,36 +143,4 @@ func (j *RunJob) deleteContainer(containerID string) error {
 	return j.Client.RemoveContainer(docker.RemoveContainerOptions{
 		ID: containerID,
 	})
-}
-
-func buildPullOptions(image string) (docker.PullImageOptions, docker.AuthConfiguration) {
-	tag := "latest"
-	registry := ""
-
-	parts := strings.Split(image, ":")
-	if len(parts) == 2 {
-		tag = parts[1]
-	}
-
-	name := parts[0]
-	parts = strings.Split(name, "/")
-	if len(parts) > 2 {
-		registry = parts[0]
-	}
-
-	return docker.PullImageOptions{
-		Repository: name,
-		Registry:   registry,
-		Tag:        tag,
-	}, buildAuthConfiguration(registry)
-}
-
-func buildAuthConfiguration(registry string) docker.AuthConfiguration {
-	var auth docker.AuthConfiguration
-	if dockercfg == nil {
-		return auth
-	}
-
-	auth, _ = dockercfg.Configs[registry]
-	return auth
 }

--- a/core/runservice.go
+++ b/core/runservice.go
@@ -1,0 +1,203 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/fsouza/go-dockerclient"
+)
+
+// Note: The ServiceJob is loosely inspired by https://github.com/alexellis/jaas/
+
+type RunServiceJob struct {
+	BareJob
+	Client  *docker.Client `json:"-"`
+	User    string         `default:"root"`
+	TTY     bool           `default:"false"`
+	Delete  bool           `default:"true"`
+	Image   string
+	Network string
+}
+
+func NewRunServiceJob(c *docker.Client) *RunServiceJob {
+	return &RunServiceJob{Client: c}
+}
+
+func (j *RunServiceJob) Run(ctx *Context) error {
+	if err := j.pullImage(); err != nil {
+		return err
+	}
+
+	svc, err := j.buildService()
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Created service %s for job %s\n", svc.ID, j.Name)
+
+	if err := j.watchContainer(svc.ID); err != nil {
+		return err
+	}
+
+	return j.deleteService(svc.ID)
+}
+
+func (j *RunServiceJob) pullImage() error {
+	o, a := buildPullOptions(j.Image)
+	if err := j.Client.PullImage(o, a); err != nil {
+		return fmt.Errorf("error pulling image %q: %s", j.Image, err)
+	}
+
+	return nil
+}
+
+func (j *RunServiceJob) buildService() (*swarm.Service, error) {
+
+	//createOptions := types.ServiceCreateOptions{}
+
+	max := uint64(1)
+	createSvcOpts := docker.CreateServiceOptions{}
+
+	createSvcOpts.ServiceSpec.TaskTemplate.ContainerSpec =
+		&swarm.ContainerSpec{
+			Image: j.Image,
+		}
+
+	// Make the service run once and not restart
+	createSvcOpts.ServiceSpec.TaskTemplate.RestartPolicy =
+		&swarm.RestartPolicy{
+			MaxAttempts: &max,
+			Condition:   swarm.RestartPolicyConditionNone,
+		}
+
+	// For a service to interact with other services in a stack,
+	// we need to attach it to the same network
+	if j.Network != "" {
+		createSvcOpts.Networks = []swarm.NetworkAttachmentConfig{
+			swarm.NetworkAttachmentConfig{
+				Target: j.Network,
+			},
+		}
+	}
+
+	if j.Command != "" {
+		createSvcOpts.ServiceSpec.TaskTemplate.ContainerSpec.Command = strings.Split(j.Command, " ")
+	}
+
+	svc, err := j.Client.CreateService(createSvcOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return svc, err
+}
+
+const (
+
+	// TODO are these const defined somewhere in the docker API?
+	swarmError   = -999
+	timeoutError = -998
+)
+
+var svcChecker = time.NewTicker(watchDuration)
+
+func (j *RunServiceJob) watchContainer(svcID string) error {
+	svcFilters := make(map[string][]string)
+	svcFilters["id"] = []string{svcID}
+
+	exitCode := swarmError
+
+	var listSvcOpts docker.ListServicesOptions
+	listSvcOpts.Filters = svcFilters
+
+	list, _ := j.Client.ListServices(listSvcOpts)
+
+	fmt.Printf("Checking for service ID %s (%s) termination\n", svcID, j.Name)
+
+	// On every tick, check if all the services have completed, or have error out
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	var err error
+	go func() {
+		defer wg.Done()
+		for _ = range svcChecker.C {
+			for _, svc := range list {
+				if svc.CreatedAt.After(time.Now().Add(maxProcessDuration)) {
+					err = ErrMaxTimeRunning
+					return
+				}
+
+				taskExitCode, found := j.findtaskstatus(svc.ID)
+				if found {
+					exitCode = taskExitCode
+					return
+				}
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	fmt.Printf("Service ID %s (%s) has completed\n", svcID, j.Name)
+	return err
+}
+
+func (j *RunServiceJob) findtaskstatus(taskID string) (int, bool) {
+	taskFilters := make(map[string][]string)
+	taskFilters["service"] = []string{taskID}
+
+	tasks, err := j.Client.ListTasks(docker.ListTasksOptions{
+		Filters: taskFilters,
+	})
+
+	if err != nil {
+		fmt.Printf("Failed to find task ID %s: %s\n", taskID, err.Error())
+		return 0, false
+	}
+
+	exitCode := 1
+	var done bool
+	stopStates := []swarm.TaskState{
+		swarm.TaskStateComplete,
+		swarm.TaskStateFailed,
+		swarm.TaskStateRejected,
+	}
+
+	for _, task := range tasks {
+
+		stop := false
+		for _, stopState := range stopStates {
+			if task.Status.State == stopState {
+				stop = true
+				break
+			}
+		}
+
+		if stop {
+
+			exitCode = task.Status.ContainerStatus.ExitCode
+
+			if exitCode == 0 && task.Status.State == swarm.TaskStateRejected {
+				exitCode = 255 // force non-zero exit for task rejected
+			}
+			done = true
+			break
+		}
+	}
+	return exitCode, done
+}
+
+func (j *RunServiceJob) deleteService(svcID string) error {
+	if !j.Delete {
+		return nil
+	}
+
+	return j.Client.RemoveService(docker.RemoveServiceOptions{
+		ID: svcID,
+	})
+}

--- a/core/runservice_test.go
+++ b/core/runservice_test.go
@@ -1,0 +1,129 @@
+package core
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/docker/docker/api/types/swarm"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/fsouza/go-dockerclient/testing"
+	logging "github.com/op/go-logging"
+
+	. "gopkg.in/check.v1"
+)
+
+const ServiceImageFixture = "test-image"
+
+type SuiteRunServiceJob struct {
+	server *testing.DockerServer
+	client *docker.Client
+}
+
+var _ = Suite(&SuiteRunServiceJob{})
+
+const logFormat = "%{color}%{shortfile} ▶ %{level}%{color:reset} %{message}"
+
+var logger Logger
+
+func (s *SuiteRunServiceJob) SetUpTest(c *C) {
+	var err error
+
+	logging.SetFormatter(logging.MustStringFormatter(logFormat))
+
+	logger = logging.MustGetLogger("ofelia")
+	s.server, err = testing.NewServer("127.0.0.1:0", nil, nil)
+	c.Assert(err, IsNil)
+
+	s.client, err = docker.NewClient(s.server.URL())
+	c.Assert(err, IsNil)
+
+	s.client.InitSwarm(docker.InitSwarmOptions{})
+
+	s.buildImage(c)
+}
+
+func (s *SuiteRunServiceJob) TestRun(c *C) {
+	job := &RunServiceJob{Client: s.client}
+	job.Image = ServiceImageFixture
+	job.Command = `echo -a foo bar`
+	job.User = "foo"
+	job.TTY = true
+	job.Delete = true
+	job.Network = "foo"
+
+	e := NewExecution()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		time.Sleep(time.Millisecond * 600)
+
+		tasks, err := s.client.ListTasks(docker.ListTasksOptions{})
+
+		c.Assert(err, IsNil)
+		fmt.Printf("found tasks %v\n", tasks[0].Spec.ContainerSpec.Command)
+
+		c.Assert(strings.Join(tasks[0].Spec.ContainerSpec.Command, ","), Equals, "echo,-a,foo,bar")
+
+		c.Assert(tasks[0].Status.State, Equals, swarm.TaskStateReady)
+
+		err = s.client.RemoveService(docker.RemoveServiceOptions{
+			ID: tasks[0].ServiceID,
+		})
+
+		c.Assert(err, IsNil)
+
+		wg.Done()
+
+	}()
+
+	err := job.Run(&Context{Execution: e, Logger: logger})
+	c.Assert(err, IsNil)
+	wg.Wait()
+
+	containers, err := s.client.ListTasks(docker.ListTasksOptions{})
+
+	c.Assert(err, IsNil)
+	c.Assert(containers, HasLen, 0)
+}
+
+func (s *SuiteRunServiceJob) TestBuildPullImageOptionsBareImage(c *C) {
+	o, _ := buildPullOptions("foo")
+	c.Assert(o.Repository, Equals, "foo")
+	c.Assert(o.Tag, Equals, "latest")
+	c.Assert(o.Registry, Equals, "")
+}
+
+func (s *SuiteRunServiceJob) TestBuildPullImageOptionsVersion(c *C) {
+	o, _ := buildPullOptions("foo:qux")
+	c.Assert(o.Repository, Equals, "foo")
+	c.Assert(o.Tag, Equals, "qux")
+	c.Assert(o.Registry, Equals, "")
+}
+
+func (s *SuiteRunServiceJob) TestBuildPullImageOptionsRegistry(c *C) {
+	o, _ := buildPullOptions("quay.io/srcd/rest:qux")
+	c.Assert(o.Repository, Equals, "quay.io/srcd/rest")
+	c.Assert(o.Tag, Equals, "qux")
+	c.Assert(o.Registry, Equals, "quay.io")
+}
+
+func (s *SuiteRunServiceJob) buildImage(c *C) {
+	inputbuf := bytes.NewBuffer(nil)
+	tr := tar.NewWriter(inputbuf)
+	tr.WriteHeader(&tar.Header{Name: "Dockerfile"})
+	tr.Write([]byte("FROM base\n"))
+	tr.Close()
+
+	err := s.client.BuildImage(docker.BuildImageOptions{
+		Name:         ServiceImageFixture,
+		InputStream:  inputbuf,
+		OutputStream: bytes.NewBuffer(nil),
+	})
+	c.Assert(err, IsNil)
+}

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.3"
+services:
+  zookeeper:
+    image: znly/zookeeper:3.4.8
+    labels:
+        - "deployment.name=mesos"
+        - "deployment.taskname=zookeeper"
+    volumes:
+      - zookeeper-data:/data/zookeeper
+    environment:
+      - ZOO_ID=1
+      - ZOO_SERVERS=zookeeper
+
+volumes:
+  zookeeper-data:
+
+

--- a/test/test-config.ini
+++ b/test/test-config.ini
@@ -1,0 +1,4 @@
+[service-run "servie-executed-on-new-container"]
+schedule = 0,20,40 * * * *
+image = ubuntu
+command =  sleep 10

--- a/test/test-config.ini
+++ b/test/test-config.ini
@@ -1,4 +1,4 @@
-[service-run "servie-executed-on-new-container"]
+[job-service-run "servie-executed-on-new-container"]
 schedule = 0,20,40 * * * *
 image = ubuntu
 command =  sleep 10


### PR DESCRIPTION
I would like to propose the following change, which adds support for docker swarm tasks. This approach adds a `job-service-run`, similar to `job-run`, but it creates a "run-once" service following an approach similar to [One-shot containers blog](https://blog.alexellis.io/containers-on-swarm/).

This allows us to create an ephemeral task which is going to run an arbitrary job, with the added benefit that this container instance can be attached to the docker swarm overlay network, which provides access to DNS resolution and enables this task to reach other running services within the docker stack.

Comments are welcome! 