### PR TITLE
Correct docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ command =  touch /tmp/example
 The easiest way to deploy **ofelia** is using *Docker*.
 
 ```sh
-docker run -it -v /etc/ofelia:/etc/ofelia mcuadros/ofelia:latest
+docker run -it -v /etc/ofelia:/etc/ofelia -v /var/run/docker.sock:/var/run/docker.sock:ro mcuadros/ofelia:latest
 ```
 
 Don't forget to place your `config.ini` at your host machine.


### PR DESCRIPTION
Current `docker run` command in README does not work out of box without mounting docker.sock.
This PR corrects the command so that it works out of box.