### PR TITLE
[docker] Add multi arch support with default support for amd64 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM golang:1.10.0 AS builder
+ARG ARCH=amd64
+
+FROM golang:1.10.0 AS builder-amd64
+
+FROM arm32v6/golang:1.10.0 AS builder-arm32v6
+
+FROM builder-${ARCH} AS builder
 
 WORKDIR ${GOPATH}/src/github.com/mcuadros/ofelia
 COPY . ${GOPATH}/src/github.com/mcuadros/ofelia


### PR DESCRIPTION
And optional support for arm32v6.

I find ofelia very usefull and think it would be nice to have it on my raspberry pi using docker, that's why I built it.

This will not affect the default image in any way, but allow for building tags with different architectures.
Pushing multiple archs via Docker Hub is currently not supported, because build args are not supported on the hub page. [Here is an example](https://github.com/raul72/docker-browsermob-proxy/blob/multi-architecture-builder/build.sh) on how this could be done automagically using Travis.