### PR TITLE
Fix docker tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG ARCH=amd64
 
 FROM golang:1.10.0 AS builder-amd64
 
-FROM arm32v6/golang:1.10.0 AS builder-arm32v6
+FROM arm32v6/golang:1.10-alpine AS builder-arm32v6
 
 FROM builder-${ARCH} AS builder
 


### PR DESCRIPTION
The golang:1.10.0 tag for the arm32v6 image doesn't exist, which is why the [build on docker hub failed](https://hub.docker.com/r/mcuadros/ofelia/builds/bqxl8tb3bcrh8d3huaut7wm/)