### PR TITLE
Add job reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,44 +56,7 @@ schedule = 0,20,40 * * * *
 image = ubuntu
 network = swarm_network
 command =  touch /tmp/example
-
-[job-service-run "job-executed-on-existing-service"]
-schedule = 0,20,40 * * * *
-service =  my-service
 ```
-
-#### Docker labels configurations
-
-In order to use this type of configurations, ofelia need access to docker socket.
-
-```sh
-docker run -it --rm \
-    -v /var/run/docker.sock:/var/run/docker.sock:ro \
-    --label ofelia.job-local.my-test-job.schedule="@every 5s" \
-    --label ofelia.job-local.my-test-job.command="date" \
-        mcuadros/ofelia:latest daemon --docker
-```
-
-Labels format: `ofelia.<JOB_TYPE>.<JOB_NAME>.<JOB_PARAMETER>=<PARAMETER_VALUE>.
-This type of configuration supports all the capabilities provided by INI files.
-
-Also, it is possible to configure `job-exec` by setting labels configurations on the target container. To do that, additional label `ofelia.enabled=true` need to be present on the target container.
-
-For example, we want `ofelia` to execute `uname -a` command in the existing container called `my_nginx`.
-To do that, we need to we need to start `my_nginx` container with next configurations:
-
-```sh
-docker run -it --rm \
-    --label ofelia.enabled=true \
-    --label ofelia.job-exec.test-exec-job.schedule="@every 5s" \
-    --label ofelia.job-exec.test-exec-job.command="uname -a" \
-        nginx
-```
-
-Now if we start `ofelia` container with the command provided above, it will pickup 2 jobs:
-
-- Local - `date`
-- Exec  - `uname -a`
 
 ### Logging
 **Ofelia** comes with three different logging drivers that can be configured in the `[global]` section:

--- a/README.md
+++ b/README.md
@@ -18,13 +18,23 @@ The main feature of **Ofelia** is the ability to execute commands directly on Do
 ## Configuration
 
 ### Jobs
-It uses a INI-style config file and the [scheduling format](https://godoc.org/github.com/robfig/cron) is exactly the same from the original `cron`, you can configure three different kind of jobs:
+
+[Scheduling format](https://godoc.org/github.com/robfig/cron) is the same as the Go implementation of `cron`. E.g. `@every 10s` or `0 0 1 * * *` (every night at 1 AM).
+
+**Note**: the format starts with seconds, instead of minutes.
+
+you can configure four different kind of jobs:
 
 - `job-exec`: this job is executed inside of a running container.
 - `job-run`: runs a command inside of a new container, using a specific image.
-- `job-local`: runs the command inside of the host running ofelia.
+- `job-local`: runs the command on the host running ofelia. **Note**: In case Ofelia is running inside a container, the command is executed inside the Ofelia container. Not on the Docker host.
 - `job-service-run`: runs the command inside a new "run-once" service, for running inside a swarm
 
+See [Jobs reference documentation](docs/jobs.md) for all available parameters.
+
+#### INI-style config
+
+Run with `ofelia daemon --config=/path/to/config.ini`
 
 ```ini
 [job-exec "job-executed-on-running-container"]
@@ -41,13 +51,49 @@ command = touch /tmp/example
 schedule = @hourly
 command = touch /tmp/example
 
-
 [job-service-run "service-executed-on-new-container"]
 schedule = 0,20,40 * * * *
 image = ubuntu
 network = swarm_network
 command =  touch /tmp/example
+
+[job-service-run "job-executed-on-existing-service"]
+schedule = 0,20,40 * * * *
+service =  my-service
 ```
+
+#### Docker labels configurations
+
+In order to use this type of configurations, ofelia need access to docker socket.
+
+```sh
+docker run -it --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    --label ofelia.job-local.my-test-job.schedule="@every 5s" \
+    --label ofelia.job-local.my-test-job.command="date" \
+        mcuadros/ofelia:latest daemon --docker
+```
+
+Labels format: `ofelia.<JOB_TYPE>.<JOB_NAME>.<JOB_PARAMETER>=<PARAMETER_VALUE>.
+This type of configuration supports all the capabilities provided by INI files.
+
+Also, it is possible to configure `job-exec` by setting labels configurations on the target container. To do that, additional label `ofelia.enabled=true` need to be present on the target container.
+
+For example, we want `ofelia` to execute `uname -a` command in the existing container called `my_nginx`.
+To do that, we need to we need to start `my_nginx` container with next configurations:
+
+```sh
+docker run -it --rm \
+    --label ofelia.enabled=true \
+    --label ofelia.job-exec.test-exec-job.schedule="@every 5s" \
+    --label ofelia.job-exec.test-exec-job.command="uname -a" \
+        nginx
+```
+
+Now if we start `ofelia` container with the command provided above, it will pickup 2 jobs:
+
+- Local - `date`
+- Exec  - `uname -a`
 
 ### Logging
 **Ofelia** comes with three different logging drivers that can be configured in the `[global]` section:
@@ -75,16 +121,8 @@ command =  touch /tmp/example
 
 ## Installation
 
-The easiest way to deploy **ofelia** is using *Docker*.
-
-```sh
-docker run -it -v /etc/ofelia:/etc/ofelia mcuadros/ofelia:latest
-```
-
-Don't forget to place your `config.ini` at your host machine.
+The easiest way to deploy **ofelia** is using *Docker*. See examples above.
 
 If don't want to run **ofelia** using our *Docker* image you can download a binary from [releases](https://github.com/mcuadros/ofelia/releases) page.
-
-
 
 > Why the project is named Ofelia? Ofelia is the name of the office assistant from the Spanish comic [Mortadelo y Filemón](https://en.wikipedia.org/wiki/Mort_%26_Phil)

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -1,0 +1,166 @@
+# Jobs reference
+
+- [job-exec](#job-exec)
+- [job-run](#job-run)
+- [job-local](#job-local)
+- [job-service-run](#job-service-run)
+
+## Job-exec
+This job is executed inside a running container. Similar to `docker exec`
+
+### Parameters
+- **Schedule** *
+  - *description*: When the job should be executed. E.g. every 10 seconds or every night at 1 AM.
+  - *value*: String, see [Scheduling format](https://godoc.org/github.com/robfig/cron) of the Go implementation of `cron`. E.g. `@every 10s` or `0 0 1 * * *` (every night at 1 AM). **Note**: the format starts with seconds, instead of minutes.
+  - *default*: Required field, no default.
+- **Command** *
+  - *description*: Command you want to run inside the container.
+  - *value*: String, e.g. `touch /tmp/example`
+  - *default*: Required field, no default.
+- **Container** *
+  - *description*: Name of the container you want to execute the command in.
+  - *value*: String, e.g. `nginx-proxy`
+  - *default*: Required field, no default.
+- **User**
+  - *description*: User as which the command should be executed, similar to `docker exec --user <user>`
+  - *value*: String, e.g. `www-data`
+  - *default*: `root`
+- **tty**
+  - *description*: Allocate a pseudo-tty, similar to `docker exec -t`. See this [Stack Overflow answer](https://stackoverflow.com/questions/30137135/confused-about-docker-t-option-to-allocate-a-pseudo-tty) for more info.
+  - *value*: Boolean, either `false` or `true`
+  - *default*: `false`
+  
+### INI-file example
+```ini
+[job-exec "flush-nginx-logs"]
+schedule = @hourly
+container = nginx-proxy
+command = /bin/bash /flush-logs.sh
+user = www-data
+tty = false
+```
+ 
+## Job-run
+This job can be used in 2 situations:
+1. To run a command inside of a new container, using a specific image. Similar to `docker run`
+2. To start a stopped container, similar to `docker start`
+
+### Parameters
+- **Schedule** * (1,2)
+  - *description*: When the job should be executed. E.g. every 10 seconds or every night at 1 AM.
+  - *value*: String, see [Scheduling format](https://godoc.org/github.com/robfig/cron) of the Go implementation of `cron`. E.g. `@every 10s` or `0 0 1 * * *` (every night at 1 AM). **Note**: the format starts with seconds, instead of minutes.
+  - *default*: Required field, no default.
+- **Command** (1)
+  - *description*: Command you want to run inside the container.
+  - *value*: String, e.g. `touch /tmp/example`
+  - *default*: Default container command
+- **Image** * (1)
+  - *description*: Image you want to use for the job.
+  - *value*: String, e.g. `nginx:latest`
+  - *default*: No default. If left blank, Ofelia assumes you will specify a container to start (situation 2).
+- **User** (1)
+  - *description*: User as which the command should be executed, similar to `docker run --user <user>`
+  - *value*: String, e.g. `www-data`
+  - *default*: `root`
+- **Network** (1)
+  - *description*: Connect the container to this network
+  - *value*: String, e.g. `backend-proxy`
+  - *default*: Optional field, no default.
+- **Delete** (1)
+  - *description*: Delete the container after the job is finished. Similar to `docker run --rm`
+  - *value*: Boolean, either `true` or `false`
+  - *default*: `true`
+- **Container** (2)
+  - *description*: Name of the container you want to start.
+  - *value*: String, e.g. `nginx-proxy`
+  - *default*: Required field in case parameter `image` is not specified, no default.
+- **tty** (1,2)
+  - *description*: Allocate a pseudo-tty, similar to `docker exec -t`. See this [Stack Overflow answer](https://stackoverflow.com/questions/30137135/confused-about-docker-t-option-to-allocate-a-pseudo-tty) for more info.
+  - *value*: Boolean, either `true` or `false`
+  - *default*: `false`
+  
+### INI-file example
+```ini
+[job-run "sync-rclone"]
+schedule = @daily
+image = rclone:latest
+command = sync remote
+user = rclone-user
+
+[job-run "update-ddns"]
+schedule = @every 15m
+container = ddns-updater
+```
+
+## Job-local
+Runs the command on the host running Ofelia.
+
+**Note**: In case Ofelia is running inside a container, the command is executed inside the container. Not on the Docker host.
+
+### Parameters
+- **Schedule** *
+  - *description*: When the job should be executed. E.g. every 10 seconds or every night at 1 AM.
+  - *value*: String, see [Scheduling format](https://godoc.org/github.com/robfig/cron) of the Go implementation of `cron`. E.g. `@every 10s` or `0 0 1 * * *` (every night at 1 AM). **Note**: the format starts with seconds, instead of minutes.
+  - *default*: Required field, no default.
+- **Command** *
+  - *description*: Command you want to run on the host.
+  - *value*: String, e.g. `touch test.txt`
+  - *default*: Required field, no default.
+- **Dir**
+  - *description*: Base directory to execute the command.
+  - *value*: String, e.g. `/tmp/sandbox/`
+  - *default*: Current directory
+- **Environment** (Broken?)
+  - *description*: List of environment variables
+  - *value*: String, e.g. `FILE=test.txt`
+  - *default*: Optional field, no default.
+
+### INI-file example
+```ini
+[job-run "touch-test-file"]
+schedule = @every 15s
+command = touch test.txt
+dir = /tmp/sandbox/
+```
+
+## Job-service-run
+Runs a command inside a new "run-once" service, for running inside a swarm.
+
+### Parameters
+- **Schedule** *
+  - *description*: When the job should be executed. E.g. every 10 seconds or every night at 1 AM.
+  - *value*: String, see [Scheduling format](https://godoc.org/github.com/robfig/cron) of the Go implementation of `cron`. E.g. `@every 10s` or `0 0 1 * * *` (every night at 1 AM). **Note**: the format starts with seconds, instead of minutes.
+  - *default*: Required field, no default.
+- **Command**
+  - *description*: Command you want to run inside the container.
+  - *value*: String, e.g. `touch /tmp/example`
+  - *default*: Default container command
+- **Image** *
+  - *description*: Image you want to use for the job.
+  - *value*: String, e.g. `nginx:latest`
+  - *default*: No default. If left blank, Ofelia assumes you will specify a container to start (situation 2).
+- **Network**
+  - *description*: Connect the container to this network
+  - *value*: String, e.g. `backend-proxy`
+  - *default*: Optional field, no default.
+- **delete**
+  - *description*: Delete the container after the job is finished.
+  - *value*: Boolean, either `true` or `false`
+  - *default*: `true`
+- **User** (1,2)
+  - *description*: User as which the command should be executed.
+  - *value*: String, e.g. `www-data`
+  - *default*: `root`
+- **tty** (1,2)
+  - *description*: Allocate a pseudo-tty, similar to `docker exec -t`. See this [Stack Overflow answer](https://stackoverflow.com/questions/30137135/confused-about-docker-t-option-to-allocate-a-pseudo-tty) for more info.
+  - *value*: Boolean, either `true` or `false`
+  - *default*: `false`
+  
+### INI-file example
+```ini
+[job-service-run "service-executed-on-new-container"]
+schedule = 0,20,40 * * * *
+image = ubuntu
+network = swarm_network
+command =  touch /tmp/example
+```


### PR DESCRIPTION
As I noticed quite some issues due to missing documentation on the original repo, I created a Jobs reference document. The document was created based on reverse engineering and trail-and-error. So, hopefully everything is correct. :)

Related issues: #22 , #44 , #56 , #69 

I also sent a PR to Trane9991's repo including docs for his docker tags:
https://github.com/Trane9991/ofelia/pull/1 