### PR TITLE
Debian based Docker Image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+docs
+tests
+static
+README.md
+LICENSE
+Dockerfile*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 docs
-tests
 static
 README.md
 LICENSE

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,0 @@
-docs
-static
-README.md
-LICENSE
-Dockerfile*

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,4 +1,4 @@
-FROM golang:1.13.10-buster AS builder
+FROM golang:1.13-buster AS builder
 
 LABEL MAINTAINER='Simone M. Zucchi<simone.zucchi@gmail.com>'
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,41 @@
+FROM golang:1.13.10-buster AS builder
+
+LABEL MAINTAINER='Simone M. Zucchi<simone.zucchi@gmail.com>'
+
+COPY . ${GOPATH}/src/github.com/mcuadros/ofelia
+
+WORKDIR ${GOPATH}/src/github.com/mcuadros/ofelia
+
+RUN go build -o /go/bin/ofelia .
+
+FROM debian:buster-slim
+
+LABEL MAINTAINER='Simone M. Zucchi<simone.zucchi@gmail.com>'
+
+ARG USERNAME=ofelia
+ARG GROUPNAME=ofelia
+ARG CA_CERTIFICATS_VER=20200601~deb10u1
+
+# these labels are required to identify container with ofelia running
+LABEL ofelia.service=true
+LABEL ofelia.enabled=true
+
+USER root
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+      ca-certificates=${CA_CERTIFICATS_VER} && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd ${USERNAME} && \
+    useradd -g ${GROUPNAME} -d /home/${USERNAME} ${USERNAME}
+
+USER $USERNAME
+
+WORKDIR /home/$USERNAME
+
+COPY --from=builder /go/bin/ofelia /usr/bin/ofelia
+
+ENTRYPOINT ["/usr/bin/ofelia"]
+
+CMD ["daemon", "--config", "/etc/ofelia/config.ini"]


### PR DESCRIPTION
Linting Dockerfile with [Hadolint](https://github.com/hadolint/hadolint) warns about package pinning:

> $ hadolint-Linux-x86_64 Dockerfile 
> Dockerfile:3 DL3018 Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
>Dockerfile:16 DL3018 Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`

This is important for a stable release, but Alpine lacks the prerequisites to achieve this. Packages are not archived in repos but to the latest release. Plus build of `Ofelia` fetches from `alpine-community` repository which has a [6 months out of support policy](https://wiki.alpinelinux.org/wiki/Enable_Community_Repository):
```
Step 9/12 : RUN apk --no-cache add ca-certificates tzdata
 ---> Running in 9f67a987896e
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz
```

The same [Alpine Community Repository page](https://wiki.alpinelinux.org/wiki/Enable_Community_Repository) links to a [Stack Overflow](https://superuser.com/questions/1055060/how-to-install-a-specific-package-version-in-alpine) page which states:

>Pinning a package to an exact version carries the risk that the package will be dropped from the repo, and your Dockerfile will fail to build in the future. The official recommendation can be read here, citation below.
>
>Alternately, you could simply set a minimum package version instead of an exact version.
>
>We don't at the moment have resources to store all built packages indefinitely in our infra. Thus we currently keep only the latest for each stable branch and has always been like that.
>
>There has been a discussion of keeping all packages tagged as Alpine in the future. However, this is still "in-progress". The official recommendation is to keep your own mirror/repository with all the specific package and their versions that you may want to use.
>
>— Timo Teräs, @fabled (Alpine)

Plus pinning to a major.minor.* fashion doesn't either in APK. It would be pointless anyway since the only the latest package is archived in repos. It would only be achieved by enabling older repos (we are at 3.12 atm, think about enabling 3.11 repo to install older stuff on 3.12 - bad practice).

In my working experience, a much more preferable way is to adopt a Debian based image. Advantages are:

1. Able to pin major.minor (and eventually forget about it)
2. No need to install build dependencies for Go ([golang:buster](https://github.com/docker-library/golang/blob/1fd658db53dda4cc4a677377e03aac01557666fe/1.13/buster/Dockerfile) image includes gcc + make)
3. tzdata package already installed:
>Reading state information...
>tzdata is already the newest version (2020a-0+deb10u1).
4. Similar build times:

>Successfully built 6567bdaaa439
>Successfully tagged ofelia:debian

>real	0m23,759s
>user	0m0,099s
>sys	0m0,077s

>Successfully built 21348a0fa533
>Successfully tagged ofelia:alpine

>real	0m18,067s
>user	0m0,081s
>sys	0m0,081s

This is a PR to achieve having a Debian based `Ofelia` image with the followings:
1. Hadolint linting pass
2. Non-privileged image
~3. Proper .dockerignore file to avoid big contexts sent over Docker Daemon~ see commit ed46a0b
4. Basing the build on `1.13-buster` image

The only drawback is a somewhat bigger image:

>$ docker images|grep ofelia
>ofelia              alpine              16db9fb0f410        51 seconds ago      22.6MB
>ofelia              debian              6567bdaaa439        10 minutes ago      91.7MB

I hope this PR is welcomed. Please review it - especially the **NON ROOT** user part. Maybe some more efforts should be done here to guarantee /var/run/docker.sock handling.

Best regards,

Simone