### PR TITLE
multiarch docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,27 +6,39 @@ on:
   push:
     branches:
       - master
+
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-
-    - name: Build image
-      uses: mr-smithers-excellent/docker-build-push@v2
-      with:
-        image: mcuadros/ofelia
-        registry: docker.io
-        username: mcuadros
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
-    - name: Tag image
-      if: github.event_name == 'release'
-      uses: mr-smithers-excellent/docker-build-push@v2
-      with:
-        image: mcuadros/ofelia
-        registry: docker.io
-        tag: latest
-        username: mcuadros
-        password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Prepare version number
+        id: prepare
+        run: |
+          VERSION=$(git describe --always --tags)
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAGS="${{secrets.DOCKER_USERNAME}}/ofelia:$VERSION,${{secrets.DOCKER_USERNAME}}/ofelia:latest"
+          else
+            TAGS="${{secrets.DOCKER_USERNAME}}/ofelia:$VERSION,${{secrets.DOCKER_USERNAME}}/ofelia:development"
+          fi
+          echo ::set-output name=tags::${TAGS}
+      
+      - name: Build the Docker image and push
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+          push: true
+          tags: ${{ steps.prepare.outputs.tags }}


### PR DESCRIPTION
Changed workflow to "official" docker tool chain to build multi-platform images (see https://github.com/docker/build-push-action). You need to set "DOCKER_USERNAME" secret to use it (you have already DOCKER_PASSWORD). This workflow will create a docker image with GIT SHA as version number and "development" tag on master and "latest" on release build. If you want to have some other version schema, please check example here: https://github.com/docker/build-push-action#complete-workflow

This workflow creates a multi arch image for linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 architectures. I tested on Raspberry PI3, but it should also work on other devices.

I changed only the "docker" workflow

You can see the output in my docker repo: https://hub.docker.com/r/spx01/ofelia/tags

This PR aims to close #112 and #77 