### PR TITLE
improve docker caching: move dependency resolution to an extra layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM golang:1.13.10-alpine AS builder
 RUN apk --no-cache add gcc musl-dev
 
 WORKDIR ${GOPATH}/src/github.com/mcuadros/ofelia
+
+# download dependencies in an extra layer -> can be cached by docker
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . ${GOPATH}/src/github.com/mcuadros/ofelia
 
 RUN go build -o /go/bin/ofelia .


### PR DESCRIPTION
This will just speed up the local docker build. Currently, all go dependencies will be downloaded each time. After this fix, go dependencies will be cached and will be downloaded if go.mod/go.sum changes