### PR TITLE
add ghcr.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,14 @@ jobs:
         registry: docker.io
         username: mcuadros
         password: ${{ secrets.DOCKER_PASSWORD }}
+    
+    - name: Build image
+      uses: mr-smithers-excellent/docker-build-push@v2
+      with:
+        image: mcuadros/ofelia
+        registry: ghcr.io
+        username: mcuadros
+        password: ${{ secrets.GITHUB_PASSWORD }}
 
     - name: Tag image
       if: github.event_name == 'release'
@@ -30,3 +38,13 @@ jobs:
         tag: latest
         username: mcuadros
         password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Tag image
+      if: github.event_name == 'release'
+      uses: mr-smithers-excellent/docker-build-push@v2
+      with:
+        image: mcuadros/ofelia
+        registry: ghcr.io
+        tag: latest
+        username: mcuadros
+        password: ${{ secrets.GITHUB_PASSWORD }}


### PR DESCRIPTION
Add an image in ghcr.io registry


## PREREQUISITES  
* create github personal access token with permissions for read/write packages as seen [here](https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images)
* add the token as a secret in this repo named GITHUB_PASSWORD
* go to github profile settings and enable enhanced support for github containers

## POST MERGE  
* after first build has been published, package needs to be made public (defaults to private)