### PR TITLE
Multiarch Docker Hub Build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,11 +19,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1 
+      - name: Cache docker layers
+        if: ${{ !env.ACT }}
+        uses: actions/cache@v2.1.4
+        id: cache
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ matrix.service }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ matrix.service }}
+            ${{ runner.os }}-buildx-
+
       - name: Prepare version number
         id: prepare
         run: |
@@ -34,10 +40,31 @@ jobs:
             TAGS="${{secrets.DOCKER_USERNAME}}/ofelia:$VERSION,${{secrets.DOCKER_USERNAME}}/ofelia:development"
           fi
           echo ::set-output name=tags::${TAGS}
-      
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+     
       - name: Build the Docker image and push
         uses: docker/build-push-action@v2
         with:
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
           push: true
           tags: ${{ steps.prepare.outputs.tags }}
+          build-args: |
+            VERSION=${{ steps.prepare.outputs.version }}
+            BUILD_DATE=${{ steps.prepare.outputs.created }}
+            GIT_REF=${{ github.sha }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.service }}
+            org.opencontainers.image.description=An ISOBlue Avena Service
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.version=${{ steps.prepare.outputs.version }}
+            org.opencontainers.image.created=${{ steps.prepare.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+            cache-from: type=local,src=/tmp/.buildx-cache
+            cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,23 +10,34 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-    - name: Build image
-      uses: mr-smithers-excellent/docker-build-push@v2
-      with:
-        image: mcuadros/ofelia
-        registry: docker.io
-        username: mcuadros
-        password: ${{ secrets.DOCKER_PASSWORD }}
-    
-    - name: Tag image
-      if: github.event_name == 'release'
-      uses: mr-smithers-excellent/docker-build-push@v2
-      with:
-        image: mcuadros/ofelia
-        registry: docker.io
-        tag: latest
-        username: mcuadros
-        password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Prepare version number
+        id: prepare
+        run: |
+          VERSION=$(git describe --always --tags)
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAGS="${{secrets.DOCKER_USERNAME}}/ofelia:$VERSION,${{secrets.DOCKER_USERNAME}}/ofelia:latest"
+          else
+            TAGS="${{secrets.DOCKER_USERNAME}}/ofelia:$VERSION,${{secrets.DOCKER_USERNAME}}/ofelia:development"
+          fi
+          echo ::set-output name=tags::${TAGS}
+      
+      - name: Build the Docker image and push
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+          push: true
+          tags: ${{ steps.prepare.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,7 +65,7 @@ jobs:
             GIT_REF=${{ github.sha }}
           labels: |
             org.opencontainers.image.title=${{ matrix.service }}
-            org.opencontainers.image.description=An ISOBlue Avena Service
+            org.opencontainers.image.description=Ofelia - a job scheduler
             org.opencontainers.image.url=${{ github.event.repository.html_url }}
             org.opencontainers.image.source=${{ github.event.repository.clone_url }}
             org.opencontainers.image.version=${{ steps.prepare.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,16 +35,22 @@ jobs:
         run: |
           VERSION=$(git describe --always --tags)
           if [ "${{ github.event_name }}" = "release" ]; then
-            TAGS="${{secrets.DOCKER_USERNAME}}/ofelia:$VERSION,${{secrets.DOCKER_USERNAME}}/ofelia:latest"
+            TAGS="mcuadros/ofelia:$VERSION,mcuadros/ofelia:latest"
+            # Replace with below once @mcuadros adds the DOCKER_USERNAME secret
+            #TAGS="${{secrets.DOCKER_USERNAME}}/ofelia:$VERSION,${{secrets.DOCKER_USERNAME}}/ofelia:latest"
           else
-            TAGS="${{secrets.DOCKER_USERNAME}}/ofelia:$VERSION,${{secrets.DOCKER_USERNAME}}/ofelia:development"
+            TAGS="mcuadros/ofelia:$VERSION,mcuadros/ofelia:development"
+            # Replace with below once @mcuadros adds the DOCKER_USERNAME secret
+            #TAGS="${{secrets.DOCKER_USERNAME}}/ofelia:$VERSION,${{secrets.DOCKER_USERNAME}}/ofelia:development"
           fi
           echo ::set-output name=tags::${TAGS}
 
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
+          username: mcuadros
+          # Replace with below once @mcuadros adds the DOCKER_USERNAME secret
+          # username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
      
       - name: Build the Docker image and push
@@ -68,3 +74,4 @@ jobs:
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
             cache-from: type=local,src=/tmp/.buildx-cache
             cache-to: type=local,dest=/tmp/.buildx-cache
+


### PR DESCRIPTION
Replacement for #121 by @0xERR0R with his permission. Builds and pushes the container to dockerhub with support for the following architectures: `linux/386`,`linux/amd64`,`linux/arm/v6`,`linux/arm/v7`,`linux/arm64`. Most recent test does not pass on my repo because I had to hardcode @mcuadros's username in, but previous commits with the proper `DOCKER_USERNAME` variable worked fine. 

Mostly a combination of @0xERR0R's PR and the workflow here https://github.com/oats-center/isoblue-avena/blob/master/.github/workflows/build-and-push-services.yml which I had a small part in writing. 

This uses @0xERR0R's scheme of tagging the docker image with GIT SHA as version number and "development" tag on master and "latest" on release build. I am happy to change this if you guys would like 

In addition to @0xERR0R's work, I added some opencontainers labels to begin to confirm to their standards, and a caching layer to hopefully speed things up. This caching layer does not work with local github actions runners like [act](https://github.com/nektos/act) so there is an `if` statement to skip that step if it detects it is being run by act

As mentioned in #121 as soon as @mcuadros adds the `DOCKER_USERNAME` variable, a followup PR should undo the hardcoded username