### PR TITLE
run-on-startup optional param for all jobs

### DIFF
--- a/core/common.go
+++ b/core/common.go
@@ -31,6 +31,7 @@ type Job interface {
 	GetName() string
 	GetSchedule() string
 	GetCommand() string
+	GetRunOnStartup() string
 	Middlewares() []Middleware
 	Use(...Middleware)
 	Run(*Context) error

--- a/core/job.go
+++ b/core/job.go
@@ -6,9 +6,10 @@ import (
 )
 
 type BareJob struct {
-	Schedule string
-	Name     string
-	Command  string
+	Schedule     string
+	Name         string
+	Command      string
+	RunOnStartup string `default:"false" gcfg:"run-on-startup" mapstructure:"run-on-startup"`
 
 	middlewareContainer
 	running int32
@@ -26,6 +27,10 @@ func (j *BareJob) GetSchedule() string {
 
 func (j *BareJob) GetCommand() string {
 	return j.Command
+}
+
+func (j *BareJob) GetRunOnStartup() string {
+	return j.RunOnStartup
 }
 
 func (j *BareJob) Running() int32 {

--- a/core/scheduler.go
+++ b/core/scheduler.go
@@ -3,6 +3,7 @@ package core
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/robfig/cron"
@@ -40,6 +41,12 @@ func (s *Scheduler) AddJob(j Job) error {
 	err := s.cron.AddJob(j.GetSchedule(), &jobWrapper{s, j})
 	if err != nil {
 		return err
+	}
+
+	runOnStartup, _ := strconv.ParseBool(j.GetRunOnStartup())
+	if runOnStartup {
+		jw := &jobWrapper{s, j}
+		jw.Run()
 	}
 
 	s.Jobs = append(s.Jobs, j)

--- a/core/scheduler_test.go
+++ b/core/scheduler_test.go
@@ -57,3 +57,18 @@ func (s *SuiteScheduler) TestMergeMiddlewaresSame(c *C) {
 	c.Assert(m, HasLen, 1)
 	c.Assert(m[0], Equals, mB)
 }
+
+func (s *SuiteScheduler) TestRunOnStartup(c *C) {
+	job := &TestJob{}
+	job.Schedule = "@hourly"
+	job.RunOnStartup = "true"
+
+	sc := NewScheduler(&TestLogger{})
+	sc.AddJob(job)
+	c.Assert(job.Called, Equals, 1)
+
+	jobTwo := &TestJob{}
+	jobTwo.Schedule = "@hourly"
+	sc.AddJob(jobTwo)
+	c.Assert(jobTwo.Called, Equals, 0)
+}

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -37,6 +37,10 @@ This job is executed inside a running container. Similar to `docker exec`
     - **INI config**: `Environment` setting can be provided multiple times for multiple environment variables.
     - **Labels config**: multiple environment variables has to be provided as JSON array: `["FOO=bar", "BAZ=qux"]`
   - *default*: Optional field, no default.
+- **run-on-startup**
+  - *description*: Runs the job once on ofelia's startup and then schedules the job normally
+  - *value*: Boolean, either false or true
+  - *default*: false
   
 ### INI-file example
 
@@ -116,6 +120,10 @@ This job can be used in 2 situations:
     - **INI config**: `Environment` setting can be provided multiple times for multiple environment variables.
     - **Labels config**: multiple environment variables has to be provided as JSON array: `["FOO=bar", "BAZ=qux"]`
   - *default*: Optional field, no default.
+- **run-on-startup**
+  - *description*: Runs the job once on ofelia's startup and then schedules the job normally
+  - *value*: Boolean, either false or true
+  - *default*: false
   
 ### INI-file example
 
@@ -172,6 +180,10 @@ Runs the command on the host running Ofelia.
     - **INI config**: `Environment` setting can be provided multiple times for multiple environment variables.
     - **Labels config**: multiple environment variables has to be provided as JSON array: `["FOO=bar", "BAZ=qux"]`
   - *default*: Optional field, no default.
+- **run-on-startup**
+  - *description*: Runs the job once on ofelia's startup and then schedules the job normally
+  - *value*: Boolean, either false or true
+  - *default*: false
 
 ### INI-file example
 
@@ -233,6 +245,10 @@ This job can be used to:
   - *description*: Allocate a pseudo-tty, similar to `docker exec -t`. See this [Stack Overflow answer](https://stackoverflow.com/questions/30137135/confused-about-docker-t-option-to-allocate-a-pseudo-tty) for more info.
   - *value*: Boolean, either `true` or `false`
   - *default*: `false`
+- **run-on-startup**
+  - *description*: Runs the job once on ofelia's startup and then schedules the job normally
+  - *value*: Boolean, either false or true
+  - *default*: false
   
 ### INI-file example
 


### PR DESCRIPTION
This pull request is in relation to Issue #79. I also have a use case for a data polling service that I would like to run once when the ofelia docker service starts up and then schedule from there. I stumbled across the issue and saw it open for help-wanted.

I added the RunOnStartup option to the BareJob struct to allow for it to apply to all job types.
Also added appropriate testing for RunOnStartup to the scheduler test suite
Also added documentation regarding the run-on-startup param to the jobs documentation