### PR TITLE
Fix syntax error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker run -it --rm \
         mcuadros/ofelia:latest daemon --docker
 ```
 
-Labels format: `ofelia.<JOB_TYPE>.<JOB_NAME>.<JOB_PARAMETER>=<PARAMETER_VALUE>.
+Labels format: `ofelia.<JOB_TYPE>.<JOB_NAME>.<JOB_PARAMETER>=<PARAMETER_VALUE>`.
 This type of configuration supports all the capabilities provided by INI files.
 
 Also, it is possible to configure `job-exec` by setting labels configurations on the target container. To do that, additional label `ofelia.enabled=true` need to be present on the target container.


### PR DESCRIPTION
There was a missing ` in the *README.md* file