### PR TITLE
Dir named by `save-folder` must already exist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ services:
 - `email-from` - mail address of the sender of the mail.
 - `mail-only-on-error` - only send a mail if the execution was not successful.
 
-- `save-folder` - directory in which the reports shall be written.
+- `save-folder` - directory in which the reports shall be written (must already exist).
 - `save-only-on-error` - only save a report if the execution was not successful.
 
 - `slack-webhook` - URL of the slack webhook.


### PR DESCRIPTION
Point out that the directory named by `save-folder` will not be created, but must already exist.