### PR TITLE
add renovate github action

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,23 @@
+name: Renovate
+on:
+  schedule:
+    # The "*" (#42, asterisk) character has special semantics in YAML, so this
+    # string has to be quoted.
+    - cron: '0/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v40.1.5
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -3,7 +3,7 @@ on:
   schedule:
     # The "*" (#42, asterisk) character has special semantics in YAML, so this
     # string has to be quoted.
-    - cron: '0/15 * * * *'
+    - cron: '15 * * * *'
   workflow_dispatch:
 
 jobs:
@@ -12,6 +12,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Summary

Test out renovate github action using `secrets.GITHUB_TOKEN`.
It has it's own limitations, but I don't have permissions to do more:

- https://github.com/[renovatebot/github-action](https://github.com/renovatebot/github-action?tab=readme-ov-file#token)?tab=readme-ov-file#token