### PR TITLE
Update cron format docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ command = touch /tmp/example
 
 
 [job-service-run "service-executed-on-new-container"]
-schedule = 0,20,40 * * * *
+schedule = 0,20,40 * * *
 image = ubuntu
 network = swarm_network
 command =  touch /tmp/example
@@ -168,7 +168,7 @@ These can be configured by setting the options listed below in the `[global]` se
 - `slack-only-on-error` - only send a slack message if the execution was not successful.
 
 ### Overlap
-**Ofelia** can prevent that a job is run twice in parallel (e.g. if the first execution didn't complete before a second execution was scheduled. If a job has the option `no-overlap` set, it will not be run concurrently. 
+**Ofelia** can prevent that a job is run twice in parallel (e.g. if the first execution didn't complete before a second execution was scheduled. If a job has the option `no-overlap` set, it will not be run concurrently.
 
 ## Installation
 

--- a/cli/config.go
+++ b/cli/config.go
@@ -87,12 +87,16 @@ func (c *Config) InitializeApp() error {
 		c.buildSchedulerMiddlewares(c.sh)
 	}
 
+	var err error
 	for name, j := range c.ExecJobs {
 		defaults.SetDefaults(j)
 		j.Client = c.dockerHandler.GetInternalDockerClient()
 		j.Name = name
 		j.buildMiddlewares()
-		c.sh.AddJob(j)
+		err = c.sh.AddJob(j)
+		if err != nil {
+			c.logger.Debugf("Unable to add new exec job %s from config: %v", name, err)
+		}
 	}
 
 	for name, j := range c.RunJobs {
@@ -100,14 +104,20 @@ func (c *Config) InitializeApp() error {
 		j.Client = c.dockerHandler.GetInternalDockerClient()
 		j.Name = name
 		j.buildMiddlewares()
-		c.sh.AddJob(j)
+		err = c.sh.AddJob(j)
+		if err != nil {
+			c.logger.Debugf("Unable to add new run job %s from config: %v", name, err)
+		}
 	}
 
 	for name, j := range c.LocalJobs {
 		defaults.SetDefaults(j)
 		j.Name = name
 		j.buildMiddlewares()
-		c.sh.AddJob(j)
+		err = c.sh.AddJob(j)
+		if err != nil {
+			c.logger.Debugf("Unable to add new local job %s from config: %v", name, err)
+		}
 	}
 
 	for name, j := range c.ServiceJobs {
@@ -115,7 +125,10 @@ func (c *Config) InitializeApp() error {
 		j.Name = name
 		j.Client = c.dockerHandler.GetInternalDockerClient()
 		j.buildMiddlewares()
-		c.sh.AddJob(j)
+		err = c.sh.AddJob(j)
+		if err != nil {
+			c.logger.Debugf("Unable to add new service job %s from config: %v", name, err)
+		}
 	}
 
 	return nil

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -41,7 +41,7 @@ This job is executed inside a running container. Similar to `docker exec`
     - **INI config**: `Environment` setting can be provided multiple times for multiple environment variables.
     - **Labels config**: multiple environment variables has to be provided as JSON array: `["FOO=bar", "BAZ=qux"]`
   - *default*: Optional field, no default.
-  
+
 ### INI-file example
 
 ```ini
@@ -78,7 +78,7 @@ This job can be used in 2 situations:
 
 - **Schedule** * (1,2)
   - *description*: When the job should be executed. E.g. every 10 seconds or every night at 1 AM.
-  - *value*: String, see [Scheduling format](https://godoc.org/github.com/robfig/cron) of the Go implementation of `cron`. E.g. `@every 10s` or `0 0 1 * * *` (every night at 1 AM). **Note**: the format starts with seconds, instead of minutes.
+  - *value*: String, see [Scheduling format](https://pkg.go.dev/github.com/robfig/cron/v3@v3.0.1#hdr-CRON_Expression_Format) of the Go implementation of `cron`. E.g. `@every 10s` or `0 1 * * *` (every night at 1 AM).
   - *default*: Required field, no default.
 - **Command** (1)
   - *description*: Command you want to run inside the container.
@@ -130,7 +130,7 @@ This job can be used in 2 situations:
     - **INI config**: setting can be provided multiple times for multiple environment variables.
     - **Labels config**: multiple environment variables has to be provided as JSON array: `["FOO=bar", "BAZ=qux"]`
   - *default*: Optional field, no default.
-  
+
 ### INI-file example
 
 ```ini
@@ -171,7 +171,7 @@ Runs the command on the host running Ofelia.
 
 - **Schedule** *
   - *description*: When the job should be executed. E.g. every 10 seconds or every night at 1 AM.
-  - *value*: String, see [Scheduling format](https://godoc.org/github.com/robfig/cron) of the Go implementation of `cron`. E.g. `@every 10s` or `0 0 1 * * *` (every night at 1 AM). **Note**: the format starts with seconds, instead of minutes.
+  - *value*: String, see [Scheduling format](https://pkg.go.dev/github.com/robfig/cron/v3@v3.0.1#hdr-CRON_Expression_Format) of the Go implementation of `cron`. E.g. `@every 10s` or `0 1 * * *` (every night at 1 AM).
   - *default*: Required field, no default.
 - **Command** *
   - *description*: Command you want to run on the host.
@@ -222,7 +222,7 @@ This job can be used to:
 
 - **Schedule** * (1,2)
   - *description*: When the job should be executed. E.g. every 10 seconds or every night at 1 AM.
-  - *value*: String, see [Scheduling format](https://godoc.org/github.com/robfig/cron) of the Go implementation of `cron`. E.g. `@every 10s` or `0 0 1 * * *` (every night at 1 AM). **Note**: the format starts with seconds, instead of minutes.
+  - *value*: String, see [Scheduling format](https://pkg.go.dev/github.com/robfig/cron/v3@v3.0.1#hdr-CRON_Expression_Format) of the Go implementation of `cron`. E.g. `@every 10s` or `0 1 * * *` (every night at 1 AM).
   - *default*: Required field, no default.
 - **Command** (1, 2)
   - *description*: Command you want to run inside the container.
@@ -248,12 +248,12 @@ This job can be used to:
   - *description*: Allocate a pseudo-tty, similar to `docker exec -t`. See this [Stack Overflow answer](https://stackoverflow.com/questions/30137135/confused-about-docker-t-option-to-allocate-a-pseudo-tty) for more info.
   - *value*: Boolean, either `true` or `false`
   - *default*: `false`
-  
+
 ### INI-file example
 
 ```ini
 [job-service-run "service-executed-on-new-container"]
-schedule = 0,20,40 * * * *
+schedule = 0,20,40 * * *
 image = ubuntu
 network = swarm_network
 command =  touch /tmp/example


### PR DESCRIPTION
Hi, 
I noticed that you updated the `cron` package on the 0.4.0-beta version. Unlike the old cron package [robfig/cron/v1](https://pkg.go.dev/github.com/robfig/cron) does the new cron package [robfig/cron/v3](https://pkg.go.dev/github.com/robfig/cron/v3@v3.0.1#hdr-CRON_Expression_Format) no longer support seconds in the format. 

I've also added logs to all instances where new jobs are created since the error produced was not logged anywhere. 

closes #351 