### PR TITLE
use tini to reap zombie processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ FROM alpine:3.22
 LABEL ofelia.service=true
 LABEL ofelia.enabled=true
 
-RUN apk --no-cache add ca-certificates tzdata
+RUN apk --no-cache add ca-certificates tini tzdata
 
 COPY --from=builder /go/bin/ofelia /usr/bin/ofelia
 
-ENTRYPOINT ["/usr/bin/ofelia"]
+ENTRYPOINT ["/sbin/tini", "/usr/bin/ofelia"]
 
 CMD ["daemon", "--config", "/etc/ofelia/config.ini"]


### PR DESCRIPTION
Fix for #394 

This does add a small dependency, but `tini` is small and well-tested.

I was also playing around with a pure go solution in https://github.com/boyvinall/ofelia/tree/go-reaper but it looks like that package will `fmt.Printf` some messages, which seems non-ideal. Also, I think it's nice to only implement this when you're sure it's running as PID 1.