### PR TITLE
Add job-run entrypoint override option

### DIFF
--- a/core/runjob.go
+++ b/core/runjob.go
@@ -33,6 +33,7 @@ type RunJob struct {
 	Network     string
 	Hostname    string
 	Container   string
+	Entrypoint  *string
 	Volume      []string
 	VolumesFrom []string `gcfg:"volumes-from" mapstructure:"volumes-from,"`
 	Environment []string
@@ -163,18 +164,22 @@ func (j *RunJob) pullImage() error {
 }
 
 func (j *RunJob) buildContainer() (*docker.Container, error) {
+	config := &docker.Config{
+		Image:        j.Image,
+		AttachStdin:  false,
+		AttachStdout: true,
+		AttachStderr: true,
+		Tty:          j.TTY,
+		Cmd:          args.GetArgs(j.Command),
+		User:         j.User,
+		Env:          j.Environment,
+		Hostname:     j.Hostname,
+	}
+	if j.Entrypoint != nil {
+		config.Entrypoint = args.GetArgs(*j.Entrypoint)
+	}
 	c, err := j.Client.CreateContainer(docker.CreateContainerOptions{
-		Config: &docker.Config{
-			Image:        j.Image,
-			AttachStdin:  false,
-			AttachStdout: true,
-			AttachStderr: true,
-			Tty:          j.TTY,
-			Cmd:          args.GetArgs(j.Command),
-			User:         j.User,
-			Env:          j.Environment,
-			Hostname:     j.Hostname,
-		},
+		Config:           config,
 		NetworkingConfig: &docker.NetworkingConfig{},
 		HostConfig: &docker.HostConfig{
 			Binds:       j.Volume,

--- a/core/runjob_test.go
+++ b/core/runjob_test.go
@@ -33,56 +33,71 @@ func (s *SuiteRunJob) SetUpTest(c *C) {
 }
 
 func (s *SuiteRunJob) TestRun(c *C) {
-	job := &RunJob{Client: s.client}
-	job.Image = ImageFixture
-	job.Command = `echo -a "foo bar"`
-	job.User = "foo"
-	job.TTY = true
-	job.Delete = "true"
-	job.Network = "foo"
-	job.Hostname = "test-host"
-	job.Name = "test"
-	job.Environment = []string{"test_Key1=value1", "test_Key2=value2"}
-	job.Volume = []string{"/test/tmp:/test/tmp:ro", "/test/tmp:/test/tmp:rw"}
+	overridenEntrypoint := "/bin/bash -c"
+	emptyEntrypoint := ""
+	testCases := []struct {
+		entrypoint         *string
+		expectedEntrypoint []string
+	}{
+		{nil, nil},
+		{&overridenEntrypoint, []string{"/bin/bash", "-c"}},
+		{&emptyEntrypoint, []string{}},
+	}
 
-	ctx := &Context{}
-	ctx.Execution = NewExecution()
-	ctx.Logger = NewSlogLogger(io.Discard)
-	ctx.Job = job
+	for _, tc := range testCases {
+		job := &RunJob{Client: s.client}
+		job.Image = ImageFixture
+		job.Command = `echo -a "foo bar"`
+		job.User = "foo"
+		job.TTY = true
+		job.Delete = "true"
+		job.Network = "foo"
+		job.Hostname = "test-host"
+		job.Name = "test"
+		job.Environment = []string{"test_Key1=value1", "test_Key2=value2"}
+		job.Volume = []string{"/test/tmp:/test/tmp:ro", "/test/tmp:/test/tmp:rw"}
+		job.Entrypoint = tc.entrypoint
 
-	go func() {
-		// Docker Test Server doesn't actually start container
-		// so "job.Run" will hang until container is stopped
-		if err := job.Run(ctx); err != nil {
-			c.Fatal(err)
-		}
-	}()
+		ctx := &Context{}
+		ctx.Execution = NewExecution()
+		ctx.Logger = NewSlogLogger(io.Discard)
+		ctx.Job = job
 
-	time.Sleep(200 * time.Millisecond)
-	container, err := job.getContainer()
-	c.Assert(err, IsNil)
-	c.Assert(container.Config.Cmd, DeepEquals, []string{"echo", "-a", "foo bar"})
-	c.Assert(container.Config.User, Equals, job.User)
-	c.Assert(container.Config.Image, Equals, job.Image)
-	c.Assert(container.State.Running, Equals, true)
-	c.Assert(container.Config.Env, DeepEquals, job.Environment)
+		go func() {
+			// Docker Test Server doesn't actually start container
+			// so "job.Run" will hang until container is stopped
+			if err := job.Run(ctx); err != nil {
+				c.Fatal(err)
+			}
+		}()
 
-	// this doesn't seem to be working with DockerTestServer
-	// c.Assert(container.Config.Hostname, Equals, job.Hostname)
-	// c.Assert(container.HostConfig.Binds, DeepEquals, job.Volume)
+		time.Sleep(200 * time.Millisecond)
+		container, err := job.getContainer()
+		c.Assert(err, IsNil)
+		c.Assert(container.Config.Entrypoint, DeepEquals, tc.expectedEntrypoint)
+		c.Assert(container.Config.Cmd, DeepEquals, []string{"echo", "-a", "foo bar"})
+		c.Assert(container.Config.User, Equals, job.User)
+		c.Assert(container.Config.Image, Equals, job.Image)
+		c.Assert(container.State.Running, Equals, true)
+		c.Assert(container.Config.Env, DeepEquals, job.Environment)
 
-	// stop container, we don't need it anymore
-	err = job.stopContainer(0)
-	c.Assert(err, IsNil)
+		// this doesn't seem to be working with DockerTestServer
+		// c.Assert(container.Config.Hostname, Equals, job.Hostname)
+		// c.Assert(container.HostConfig.Binds, DeepEquals, job.Volume)
 
-	// wait and double check if container was deleted on "stop"
-	time.Sleep(watchDuration * 2)
-	container, _ = job.getContainer()
-	c.Assert(container, IsNil)
+		// stop container, we don't need it anymore
+		err = job.stopContainer(0)
+		c.Assert(err, IsNil)
 
-	containers, err := s.client.ListContainers(docker.ListContainersOptions{All: true})
-	c.Assert(err, IsNil)
-	c.Assert(containers, HasLen, 0)
+		// wait and double check if container was deleted on "stop"
+		time.Sleep(watchDuration * 2)
+		container, _ = job.getContainer()
+		c.Assert(container, IsNil)
+
+		containers, err := s.client.ListContainers(docker.ListContainersOptions{All: true})
+		c.Assert(err, IsNil)
+		c.Assert(containers, HasLen, 0)
+	}
 }
 
 func (s *SuiteRunJob) TestBuildPullImageOptionsBareImage(c *C) {

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -84,6 +84,10 @@ This job can be used in 2 situations:
   - *description*: Command you want to run inside the container.
   - *value*: String, e.g. `touch /tmp/example`
   - *default*: Default container command
+- **Entrypoint** (1)
+  - *description*: Override container default entrypoint.
+  - *value*: String, e.g. `/bin/bash -c`
+  - *default*: Default container entrypoint
 - **Image** (1)
   - *description*: Image you want to use for the job.
   - *value*: String, e.g. `nginx:latest`


### PR DESCRIPTION
Should resolve #236.

Differences from https://github.com/mcuadros/ofelia/pull/323:
* Added a possibility to make entrypoint empty
* Added test cases

Let me know if there are any questions/comments.