### PR TITLE
chore: update Renovate GitHub Action

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v43.0.3
+        uses: renovatebot/github-action@v46.1.13
         env:
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
           LOG_LEVEL: "${{inputs.log-level || 'info'}}"


### PR DESCRIPTION
## Summary
- update the self-hosted Renovate workflow from `renovatebot/github-action@v43.0.3` to `v46.1.13`
- keep the existing repository selection, log-level input, and `GITHUB_TOKEN` wiring unchanged

## Verification
- `git diff --check`

This is a workflow-only maintenance update, so I did not run the project test suite.